### PR TITLE
Add docker compose compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@
 # 2. Build the image
 #     $ docker build -t webgme-docker-worker .
 
-# https://github.com/nodejs/docker-node/blob/3b038b8a1ac8f65e3d368bedb9f979884342fdcb/6.9/Dockerfile
-FROM node:boron
+# Node 8
+FROM node:carbon
 
 RUN mkdir /usr/app
 
@@ -20,7 +20,7 @@ ADD . /usr/app/
 RUN npm install
 
 # Needed only if webgme is a peerDependency
-RUN npm install webgme
+RUN npm install webgme-engine
 
 # Uncomment this line if webgme-docker-worker-manager is a node_module (which is probably is).
 # RUN cp /usr/app/node_modules/webgme-docker-worker-manager/dockerworker.js /usr/app/dockerworker.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD . /usr/app/
 RUN npm install
 
 # Needed only if webgme is a peerDependency
-RUN npm install webgme
+RUN npm install webgme-engine
 
 # Uncomment this line if webgme-docker-worker-manager is a node_module (which is probably is).
 # RUN cp /usr/app/node_modules/webgme-docker-worker-manager/dockerworker.js /usr/app/dockerworker.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD . /usr/app/
 RUN npm install
 
 # Needed only if webgme is a peerDependency
-RUN npm install webgme-engine
+RUN npm install webgme
 
 # Uncomment this line if webgme-docker-worker-manager is a node_module (which is probably is).
 # RUN cp /usr/app/node_modules/webgme-docker-worker-manager/dockerworker.js /usr/app/dockerworker.js

--- a/DockerfileServer
+++ b/DockerfileServer
@@ -12,6 +12,6 @@ ADD . /usr/app/
 RUN npm install
 
 # Needed only if webgme is a peerDependency
-RUN npm install webgme-engine
+RUN npm install webgme
 
 CMD ["npm", "start"]

--- a/DockerfileServer
+++ b/DockerfileServer
@@ -12,6 +12,6 @@ ADD . /usr/app/
 RUN npm install
 
 # Needed only if webgme is a peerDependency
-RUN npm install webgme
+RUN npm install webgme-engine
 
 CMD ["npm", "start"]

--- a/DockerfileServer
+++ b/DockerfileServer
@@ -14,7 +14,4 @@ RUN npm install
 # Needed only if webgme is a peerDependency
 RUN npm install webgme-engine
 
-# Uncomment this line if webgme-docker-worker-manager is a node_module (which is probably is).
-# RUN cp /usr/app/node_modules/webgme-docker-worker-manager/dockerworker.js /usr/app/dockerworker.js
-
 CMD ["npm", "start"]

--- a/DockerfileServer
+++ b/DockerfileServer
@@ -1,0 +1,20 @@
+# Node 8
+FROM node:carbon
+
+RUN mkdir /usr/app
+
+WORKDIR /usr/app
+
+# copy app source
+ADD . /usr/app/
+
+# Install the node-modules.
+RUN npm install
+
+# Needed only if webgme is a peerDependency
+RUN npm install webgme-engine
+
+# Uncomment this line if webgme-docker-worker-manager is a node_module (which is probably is).
+# RUN cp /usr/app/node_modules/webgme-docker-worker-manager/dockerworker.js /usr/app/dockerworker.js
+
+CMD ["npm", "start"]

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -15,21 +15,33 @@ config.server.workerManager.path = path.join(__dirname, '../dockerworkermanager'
 // These are the default options - this section can be left out..
 config.server.workerManager.options = {
     //dockerode: null, // https://github.com/apocas/dockerode#getting-started
-    network: 'bridge',
+
     image: 'webgme-docker-worker', // By default all plugins will from this images
     maxRunningContainers: 2,
     keepContainersAtFailure: false,
-    // This should be a port to the webgme server on the host.
-    // If the webgme server is running on the host - the default fallback of config.server.port will work.
-    // This is needed if the webgme server itself is running inside a docker container and its port
-    // isn't map to the same host port.
-    // webgmeServerPort: <config.server.port>,
-
     // Specific image to use for plugin. Set to null if plugin shouldn't run within docker container.
     pluginToImage: {
         // PluginGenerator: null,
         // ConfigurationArtifact: 'another-image'
     },
+
+    // The docker network used. By default containers are running within the bridge network and
+    // can access the host at that network. Unless webgmeUrl is specified the dockerworkermanager can
+    // figure out the host IP by querying the network. If using another network than bridge - this
+    // process only works if the host is accessible from that network. (Consider using webgmeUrl for more
+    // restricted networks.
+    network: 'bridge',
+
+    // If the webgme server is running on the host - the default fallback of config.server.port will work.
+    // This can be needed if the webgme server itself is running inside a docker container and its port
+    // isn't map to the same host port. It typically requires the default bridge network to be used.
+    webgmeServerPort: null,
+
+    // If specified will be used as the full webgme server url from the perspective of a
+    // running docker worker.
+    // This is needed when connecting to the webgme server container directly (without going through the host).
+    // When defined  the network and webgmeServerPort options aren't used.
+    webgmeUrl: null,
 };
 
 validateConfig(config);

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -1,7 +1,7 @@
 /*jshint node: true*/
 'use strict';
 
-var config = require('webgme-engine/config/config.default'),
+var config = require('webgme/config/config.default'),
     validateConfig = require('webgme-engine/config/validator').validateConfig,
     path = require('path');
 

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -1,7 +1,7 @@
 /*jshint node: true*/
 'use strict';
 
-var config = require('webgme/config/config.default'),
+var config = require('webgme-engine/config/config.default'),
     validateConfig = require('webgme-engine/config/validator').validateConfig,
     path = require('path');
 

--- a/config/config.docker.js
+++ b/config/config.docker.js
@@ -1,6 +1,5 @@
 /* globals process, require, module */
 const config = require('./config.default');
-//const validateConfig = require('webgme-engine/config/validator');
 
 // This is only for testing - it will persist everything inside the containers.
 config.mongo.uri = 'mongodb://' + process.env.MONGO_IP + ':27017/multi';

--- a/config/config.docker.js
+++ b/config/config.docker.js
@@ -1,11 +1,12 @@
 /* globals process, require, module */
-const config = require('./config.webgme');
-const validateConfig = require('webgme-engine/config/validator');
+const config = require('./config.default');
+//const validateConfig = require('webgme-engine/config/validator');
 
 // This is only for testing - it will persist everything inside the containers.
 config.mongo.uri = 'mongodb://' + process.env.MONGO_IP + ':27017/multi';
 config.server.workerManager.options.webgmeUrl = 'http://' + process.env.WEBGME_IP + ':' + config.server.port;
+config.server.workerManager.options.image = 'docker-worker-manager_webgme-docker-worker';
 
 
-validateConfig(config);
+//validateConfig(config);
 module.exports = config;

--- a/config/config.docker.js
+++ b/config/config.docker.js
@@ -1,0 +1,11 @@
+/* globals process, require, module */
+const config = require('./config.webgme');
+const validateConfig = require('webgme-engine/config/validator');
+
+// This is only for testing - it will persist everything inside the containers.
+config.mongo.uri = 'mongodb://' + process.env.MONGO_IP + ':27017/multi';
+config.server.workerManager.options.webgmeUrl = 'http://' + process.env.WEBGME_IP + ':' + config.server.port;
+
+
+validateConfig(config);
+module.exports = config;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,9 @@
 version: '3'
 services:
   webgme-server:
-    build: .
-    dockerfile: DockerfileServer
+    build: 
+      context: .
+      dockerfile: DockerfileServer
     depends_on:
       - mongo
     environment:
@@ -24,7 +25,7 @@ services:
   mongo:
     image: mongo:3.4.1
     ports:
-      #- 27017:27017 # Uncomment to expose mongo-port on host
+      - 27017:27017 # Uncomment to expose mongo-port on host
   webgme-docker-worker:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
   webgme-docker-worker:
     build:
       context: .
-    command: ["cat", "/dev/null"] # A no-op command so the image is built.
+    depends_on:
+      - webgme-server
     environment:
       - NODE_ENV=docker
       - WEBGME_IP=webgme-server
+    command: ["cat", "/dev/null"] # A no-op command so the image is built.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+# To build and launch (first time):
+#   $ docker-compose up -d
+# To create new images (--no-cache) to force building from scratch:
+#   $ docker-compose build
+# To launch again (leave out -d for non daemon launch):
+#   $ docker-compose up -d
+# To stop containers:
+#  $ docker-compose stop
+version: '3'
+services:
+  webgme-server:
+    build: .
+    dockerfile: DockerfileServer
+    depends_on:
+      - mongo
+    environment:
+      - NODE_ENV=docker
+      - MONGO_IP=mongo
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+     # Change the LHS to map to other port on host
+     - 8888:8888
+  mongo:
+    image: mongo:3.4.1
+    ports:
+      #- 27017:27017 # Uncomment to expose mongo-port on host
+  webgme-docker-worker:
+    build:
+      context: .
+    command: ["cat", "/dev/null"] # A no-op command so the image is built.
+    environment:
+      - NODE_ENV=docker
+      - WEBGME_IP=webgme-server


### PR DESCRIPTION
Add new option `webgmeUrl` to specify webgme-url rather than relying on bridge network look-up.
See `docker-compose.yml` and `config.docker.js` or example.