### PR TITLE
 Add option createParams to allow setting/overwriting container parameters

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -42,6 +42,13 @@ config.server.workerManager.options = {
     // This is needed when connecting to the webgme server container directly (without going through the host).
     // When defined  the network and webgmeServerPort options aren't used.
     webgmeUrl: null,
+
+    // Key-value pair for passing in additional parameters or overwriting the default passed from this module.
+    // Example: Limit containers memory to 512Mb {HostConfig: {Memory: 536870912}}
+    // Before modifying this make sure not to overwrite anything that the manager strictly depends on.
+    // Check the code in dockerworkermanager.js - search for dockerParams.
+    // https://docs.docker.com/engine/api/v1.37/#operation/ContainerCreate
+    createParams: null,
 };
 
 validateConfig(config);

--- a/config/config.docker.js
+++ b/config/config.docker.js
@@ -5,7 +5,17 @@ const config = require('./config.default');
 config.mongo.uri = 'mongodb://' + process.env.MONGO_IP + ':27017/multi';
 config.server.workerManager.options.webgmeUrl = 'http://' + process.env.WEBGME_IP + ':' + config.server.port;
 config.server.workerManager.options.image = 'docker-worker-manager_webgme-docker-worker';
+config.server.workerManager.options.createParams = {
+    HostConfig: {
+        Memory: 536870912
+    }
+};
 
+config.seedProjects.createAtStartup = [{
+    projectName: 'Example',
+    seedId: 'EmptyProject',
+    creatorId: 'guest'
+}];
 
 //validateConfig(config);
 module.exports = config;

--- a/config/config.docker.js
+++ b/config/config.docker.js
@@ -14,7 +14,8 @@ config.server.workerManager.options.createParams = {
 config.seedProjects.createAtStartup = [{
     projectName: 'Example',
     seedId: 'EmptyProject',
-    creatorId: 'guest'
+    creatorId: 'guest',
+    rights: {}
 }];
 
 //validateConfig(config);


### PR DESCRIPTION
```
    // Key-value pair for passing in additional parameters or overwriting the default passed from this module.
    // Example: Limit containers memory to 512Mb {HostConfig: {Memory: 536870912}}
    // Before modifying this make sure not to overwrite anything that the manager strictly depends on.
    // Check the code in dockerworkermanager.js - search for dockerParams.
    // https://docs.docker.com/engine/api/v1.37/#operation/ContainerCreate
    createParams: null,
```